### PR TITLE
feat: add include and exclude globs

### DIFF
--- a/marathon/COMPLETION.md
+++ b/marathon/COMPLETION.md
@@ -1,0 +1,11 @@
+# Marathon
+
+*Marathon is a parallel script execution runtime that automatically discovers and runs generator scripts to automate the creation of content at scale.*
+
+## Features
+
+-   **Parallel Execution**: Run multiple generator scripts simultaneously for faster processing
+-   **Flexible Deployment**: Works as a Regolith filter or standalone tool
+-   **Environment Integration**: Automatic setup of environment variables for BP/RP directories
+-   **Library Support**: Smart handling of library files and TypeScript definitions
+-   **Working Directory Management**: Each script runs in its appropriate context

--- a/marathon/schema.json
+++ b/marathon/schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "marathon/config.schema.json",
+  "title": "Marathon Config",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "root_dir": {
+      "type": "string",
+      "description": "Root directory the marathon scripts run from.",
+      "default": "./"
+    },
+    "include": {
+      "type": "array",
+      "description": "Glob patterns to include when finding marathon scripts. Takes precedence over excludes.",
+      "items": {
+        "type": "string"
+      },
+      "default": [
+        "data/marathon/**/*.ts",
+        "data/marathon/**/*.js"
+      ]
+    },
+    "exclude": {
+      "type": "array",
+      "description": "Glob patterns to exclude when finding files.",
+      "items": {
+        "type": "string"
+      },
+      "default": [
+        "data/**/*.ts",
+        "data/**/*.js"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds `include` and `exclude` fields to the config. Those are glob patterns, that allow the user to include or exclude files. Check to only process files in data directory that are only in marathon subfolder has been rewritten to use those patterns.

As a bonus I added schema.json and COMPLETION.md, that are used by regolith vscode extension.