### PR TITLE
Marathon: Improved compatibility with Regolith's tmp_dir setting

### DIFF
--- a/marathon/marathon.ts
+++ b/marathon/marathon.ts
@@ -18,16 +18,23 @@ let denoConfig: string | undefined;
 if (config.deno_config !== undefined) {
     denoConfig = resolve(config.deno_config);
 } else {
-    for (const name of ['deno.json', 'deno.jsonc']) {
-        const p = join(rootDir, name);
-        try {
-            const info = await Deno.stat(p);
-            if (info.isFile) {
-                denoConfig = p;
-                break;
+    const searchRoots = [rootDir];
+    const regolithProjectRoot = Deno.env.get('ROOT_DIR');
+    if (regolithProjectRoot !== undefined) {
+        searchRoots.push(regolithProjectRoot); // Always true
+    }
+    for (const searchRoot of searchRoots) {
+        for (const name of ['deno.json', 'deno.jsonc']) {
+            const p = join(searchRoot, name);
+            try {
+                const info = await Deno.stat(p);
+                if (info.isFile) {
+                    denoConfig = p;
+                    break;
+                }
+            } catch {
+                /* not found */
             }
-        } catch {
-            /* not found */
         }
     }
 }


### PR DESCRIPTION
This PR fixes issue #11. Recent updates to Marathon did not help with the issue. I attached a simple test project for Regolith. It compiles correctly with my version but it crashes when you try running it with`tmp_dir` pointing at a different drive when used with Marathon `1.3.0`. It returns following error:
```
[ERROR]	[marathon] error: Relative import path "#marathon/some_data.lib.ts" not prefixed with / or ./ or ../
[ERROR]	[marathon]     at file:///R:/6437569ea9cdd8ac943757b9e2a514c1/BP/blocks/colored_blocks.ts:2:24
[ERROR]	Failed to run profile ""
```
The problem is that currently (v1.3.0) Marathon doesn't look for `deno.json` in the root of the Regolith project.

Test project:
[marathon-test.zip](https://github.com/user-attachments/files/28162913/marathon-test.zip)
