### PR TITLE
Add `dropLabels` functionality to `dinoscript`

### DIFF
--- a/dinoscript/README.md
+++ b/dinoscript/README.md
@@ -44,6 +44,7 @@ Your entry file lives at `data/dinoscript/src/main.ts`.
 | disableManifestModification | `boolean`                            | `false`                | Skip all `BP/manifest.json` editing                                                          |
 | manifest                    | `string`                             | `"BP/manifest.json"`   | Path to the BP manifest                                                                      |
 | rolldownConfig              | `string \| false`                    | `"rolldown.config.ts"` | Path to optional rolldown config in `data/dinoscript/`. Set to `false` to disable.           |
+| dropLabels                  | `string[]`                           | —                      | Label names to strip from the bundle (e.g. `["DEBUG"]` removes all `DEBUG: { ... }` blocks)  |
 
 ## Custom rolldown config
 

--- a/dinoscript/bundle.ts
+++ b/dinoscript/bundle.ts
@@ -87,6 +87,7 @@ export async function runBundle(config: Config): Promise<void> {
         external,
         platform: 'neutral',
         plugins: [denoPlugin(denoPluginOptions)],
+        ...(config.dropLabels !== undefined && { transform: { dropLabels: config.dropLabels } }),
     };
 
     let outputOptions: OutputOptions = {

--- a/dinoscript/config.ts
+++ b/dinoscript/config.ts
@@ -24,6 +24,7 @@ export interface Config {
     disableManifestModification: boolean;
     manifest: string;
     rolldownConfig: string | false;
+    dropLabels: string[] | undefined;
 }
 
 function fail(msg: string): never {
@@ -91,6 +92,17 @@ export async function parseConfig(raw: unknown): Promise<Config> {
         fail('`rolldownConfig` must be a string or false');
     }
 
+    let dropLabels: string[] | undefined;
+    if (s.dropLabels !== undefined) {
+        if (
+            !Array.isArray(s.dropLabels) ||
+            (s.dropLabels as unknown[]).some((l) => typeof l !== 'string')
+        ) {
+            fail('`dropLabels` must be an array of strings');
+        }
+        dropLabels = s.dropLabels as string[];
+    }
+
     return {
         entry,
         modules,
@@ -108,5 +120,6 @@ export async function parseConfig(raw: unknown): Promise<Config> {
                 : false,
         manifest: typeof s.manifest === 'string' ? s.manifest : 'BP/manifest.json',
         rolldownConfig,
+        dropLabels,
     };
 }

--- a/dinoscript/dinoscript.test.ts
+++ b/dinoscript/dinoscript.test.ts
@@ -20,6 +20,7 @@ Deno.test('parseConfig - applies all defaults', async () => {
     assertEquals(config.disableManifestModification, false);
     assertEquals(config.manifest, 'BP/manifest.json');
     assertEquals(config.rolldownConfig, 'rolldown.config.ts');
+    assertEquals(config.dropLabels, undefined);
 });
 
 Deno.test('parseConfig - normalises entry string to array', async () => {
@@ -95,6 +96,38 @@ Deno.test('parseConfig - invalid format rejects', async () => {
         () => parseConfig({ modules: ['@minecraft/server@1.0.0'], format: 'invalid' }),
         Error,
         'format',
+    );
+});
+
+Deno.test('parseConfig - dropLabels accepts array of strings', async () => {
+    const config = await parseConfig({
+        modules: ['@minecraft/server@1.0.0'],
+        dropLabels: ['DEBUG', 'DEV'],
+    });
+    assertEquals(config.dropLabels, ['DEBUG', 'DEV']);
+});
+
+Deno.test('parseConfig - dropLabels accepts empty array', async () => {
+    const config = await parseConfig({
+        modules: ['@minecraft/server@1.0.0'],
+        dropLabels: [],
+    });
+    assertEquals(config.dropLabels, []);
+});
+
+Deno.test('parseConfig - dropLabels with non-string items rejects', async () => {
+    await assertRejects(
+        () => parseConfig({ modules: ['@minecraft/server@1.0.0'], dropLabels: [42] }),
+        Error,
+        'dropLabels',
+    );
+});
+
+Deno.test('parseConfig - dropLabels non-array rejects', async () => {
+    await assertRejects(
+        () => parseConfig({ modules: ['@minecraft/server@1.0.0'], dropLabels: 'DEBUG' }),
+        Error,
+        'dropLabels',
     );
 });
 

--- a/dinoscript/schema.json
+++ b/dinoscript/schema.json
@@ -89,6 +89,12 @@
             ],
             "description": "Path to an optional rolldown.config.ts for custom plugins and build overrides. Set to false to disable.",
             "default": "rolldown.config.ts"
+        },
+        "dropLabels": {
+            "type": "array",
+            "description": "Label names whose labeled statements will be dropped from the bundle. Useful for stripping DEBUG: { ... } blocks in production builds.",
+            "items": { "type": "string" },
+            "uniqueItems": true
         }
     }
 }

--- a/dinoscript/test/config.json
+++ b/dinoscript/test/config.json
@@ -29,7 +29,8 @@
                         "filter": "dinoscript",
                         "settings": {
                             "modules": ["@minecraft/server@2.0.0"],
-                            "sourcemap": "linked"
+                            "sourcemap": "linked",
+                            "dropLabels": ["DEBUG"]
                         }
                     },
                     {

--- a/dinoscript/test/packs/data/dinoscript/src/main.ts
+++ b/dinoscript/test/packs/data/dinoscript/src/main.ts
@@ -6,3 +6,7 @@ const log = Logger.getLogger('Dinoscript');
 world.afterEvents.playerPlaceBlock.subscribe((event) => {
     log.info('Placed', event.block.typeId);
 });
+
+DEBUG: {
+    log.info('This is a debug message and should only appear in debug mode');
+}


### PR DESCRIPTION
This PR will add `dropLabels` functionality to `dinoscript`. This allows cleaner integration with `@bedrock-oss/bedrock-boost:Logger` and debug functionality automatic scraping.